### PR TITLE
Updated base node alpine image to 10.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11-alpine
+FROM node:10.16-alpine
 
 LABEL maintainer="Craig Mellon https://github.com/eTechSolutions/node-alpine-chromium"
 
@@ -6,6 +6,9 @@ LABEL maintainer="Craig Mellon https://github.com/eTechSolutions/node-alpine-chr
 RUN echo "http://dl-2.alpinelinux.org/alpine/edge/main" > /etc/apk/repositories
 RUN echo "http://dl-2.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN echo "http://dl-2.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+
+# Update apk package references
+RUN apk update
 
 # Install chromium
 RUN apk -U --no-cache \


### PR DESCRIPTION
As per Story #36702

Extra apk update command is needed to get around [this error](https://github.com/gliderlabs/docker-alpine/issues/207): 

![Capture](https://user-images.githubusercontent.com/31797732/63267405-dcaacd00-c289-11e9-9904-f49de595c152.PNG)

![image](https://user-images.githubusercontent.com/31797732/63267489-0fed5c00-c28a-11e9-83d2-72b4e0bfdffd.png)

